### PR TITLE
feat: add shutdown-related node

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Note: This package manages the red colored nodes.
     - Button control:
       - [/button_manager](https://github.com/eve-autonomy/button_manager)
       - [/engage_srv_converter](https://github.com/eve-autonomy/engage_srv_converter)
+      - [/button_output_selector](https://github.com/eve-autonomy/button_output_selector)
   - Reserved-delivery connection:
     - [/go_interface](https://github.com/eve-autonomy/go_interface)
   - V2I connection:
     - [/v2i_interface](https://github.com/eve-autonomy/v2i_interface)
+  - Shutdown process management:
+    - [/shutdown_manager](https://github.com/eve-autonomy/shutdown_manager)
 
 - Message definition
   - State management:

--- a/docs/node_graph.pu
+++ b/docs/node_graph.pu
@@ -42,6 +42,8 @@ rectangle "hmi control function" {
   usecase "/engage_srv_converter" #LightCoral
   usecase "/delivery_reservation_lamp_manager" #LightCoral
   usecase "/warning_lamp_manager" #LightCoral
+  usecase "/button_output_selector" #LightCoral
+  usecase "/shutdown_manager" #LightCoral
 
   usecase "/dio_ros_driver" as (/dio_ros_driver)
 
@@ -85,11 +87,14 @@ rectangle "hmi control function" {
 (/ad_status_lamp_manager) --> (/dio_ros_driver) : /dio/dout0
 
 (/delivery_reservation_button_manager) <-- (/dio_ros_driver): /dio/din1
-(/autoware_state_machine) <-- (/delivery_reservation_button_manager)
+(/button_output_selector) <-- (/delivery_reservation_button_manager)
+(/autoware_state_machine) <- (/button_output_selector)
+(/shutdown_manager) <- (/button_output_selector)
 (/engage_button_manager) <-- (/dio_ros_driver): /dio/din0
 (/engage_srv_converter) <-- (/engage_button_manager)
 
 (/autoware_state_machine) --> (/delivery_reservation_lamp_manager)
+(/shutdown_manager) --> (/delivery_reservation_lamp_manager)
 (/delivery_reservation_lamp_manager) --> (/dio_ros_driver) : /dio/dout3
 
 (/autoware_state_machine) <-- (/engage_srv_converter)

--- a/launch/proj.launch.xml
+++ b/launch/proj.launch.xml
@@ -54,10 +54,12 @@
   <include file="$(find-pkg-share button_manager)/launch/button_manager.launch.xml">
     <arg name="button_name" value="engage_button"/>
     <arg name="port_name" value="din0"/>
+    <arg name="is_publish_while_pressing_button" value="false"/>
   </include>
   <include file="$(find-pkg-share button_manager)/launch/button_manager.launch.xml">
     <arg name="button_name" value="delivery_reservation_button"/>
     <arg name="port_name" value="din1"/>
+    <arg name="is_publish_while_pressing_button" value="true"/>
   </include>
 
   <include file="$(find-pkg-share v2i_interface)/launch/v2i_interface.launch.xml">
@@ -80,4 +82,6 @@
   <include file="$(find-pkg-share autoware_state_machine)/launch/autoware_state_machine.launch.xml">
     <arg name="use_overridable_vehicle" value="$(var use_overridable_vehicle)"/>
   </include>
+  <include file="$(find-pkg-share button_output_selector)/launch/button_output_selector.launch.xml" />
+  <include file="$(find-pkg-share shutdown_manager)/launch/shutdown_manager.launch.xml" />
 </launch>


### PR DESCRIPTION
## Description

* include `button_output_selector` launch file.
* include `shutdown_manager` launch file.
* Modified to set variable `is_publish_while_pressing_button` when include `button_manager` launch file.
* Modify README to match implementation.

## Related Links

eve-autonomy/shutdown_manager#1
eve-autonomy/button_output_selector#1
eve-autonomy/delivery_reservation_lamp_manager#6
eve-autonomy/button_manager#6
eve-autonomy/autoware_state_machine#2
eve-autonomy/autoware_state_machine_msgs#1

## Review Procedure

 * [ ] Make sure the description is valid.
 * [ ] Make sure that what is described in the description matches the implementation.