### PR TITLE
feat: include button_output_selector and shutdown_manager launch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Note: This package manages the red colored nodes.
       - [audio_driver_msgs](https://github.com/eve-autonomy/audio_driver_msgs)
   - Reserved-delivery connection:
     - [go_interface](https://github.com/eve-autonomy/go_interface)
+  - Shutdown process management:
+    - [shutdown_manager_msgs](https://github.com/eve-autonomy/shutdown_manager_msgs)
 
 - Parameters
   - Reserved-delivery connection:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Note: This package manages the red colored nodes.
     - Button control:
       - [/button_manager](https://github.com/eve-autonomy/button_manager)
       - [/engage_srv_converter](https://github.com/eve-autonomy/engage_srv_converter)
+      - [/button_output_selector](https://github.com/eve-autonomy/button_output_selector)
   - Reserved-delivery connection:
     - [/go_interface](https://github.com/eve-autonomy/go_interface)
   - V2I connection:
     - [/v2i_interface](https://github.com/eve-autonomy/v2i_interface)
+  - Shutdown process management:
+    - [/shutdown_manager](https://github.com/eve-autonomy/shutdown_manager)
 
 - Message definition
   - State management:

--- a/docs/node_graph.pu
+++ b/docs/node_graph.pu
@@ -42,6 +42,8 @@ rectangle "hmi control function" {
   usecase "/engage_srv_converter" #LightCoral
   usecase "/delivery_reservation_lamp_manager" #LightCoral
   usecase "/warning_lamp_manager" #LightCoral
+  usecase "/button_output_selector" #LightCoral
+  usecase "/shutdown_manager" #LightCoral
 
   usecase "/dio_ros_driver" as (/dio_ros_driver)
 
@@ -85,11 +87,14 @@ rectangle "hmi control function" {
 (/ad_status_lamp_manager) --> (/dio_ros_driver) : /dio/dout0
 
 (/delivery_reservation_button_manager) <-- (/dio_ros_driver): /dio/din1
-(/autoware_state_machine) <-- (/delivery_reservation_button_manager)
+(/button_output_selector) <-- (/delivery_reservation_button_manager)
+(/autoware_state_machine) <- (/button_output_selector)
+(/shutdown_manager) <- (/button_output_selector)
 (/engage_button_manager) <-- (/dio_ros_driver): /dio/din0
 (/engage_srv_converter) <-- (/engage_button_manager)
 
 (/autoware_state_machine) --> (/delivery_reservation_lamp_manager)
+(/shutdown_manager) --> (/delivery_reservation_lamp_manager)
 (/delivery_reservation_lamp_manager) --> (/dio_ros_driver) : /dio/dout3
 
 (/autoware_state_machine) <-- (/engage_srv_converter)

--- a/launch/proj.launch.xml
+++ b/launch/proj.launch.xml
@@ -80,4 +80,6 @@
   <include file="$(find-pkg-share autoware_state_machine)/launch/autoware_state_machine.launch.xml">
     <arg name="use_overridable_vehicle" value="$(var use_overridable_vehicle)"/>
   </include>
+  <include file="$(find-pkg-share button_output_selector)/launch/button_output_selector.launch.xml" />
+  <include file="$(find-pkg-share shutdown_manager)/launch/shutdown_manager.launch.xml" />
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -37,6 +37,8 @@
   <exec_depend>go_interface</exec_depend>
   <exec_depend>engage_srv_converter</exec_depend>
   <exec_depend>autoware_state_machine</exec_depend>
+  <exec_depend>shutdown_manager</exec_depend>
+  <exec_depend>button_output_selector</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

* include `button_output_selector` launch file.
* include `shutdown_manager` launch file.
* Modify README to match implementation.

## Related Links

[eve-autonomy/proj_launch#7](https://github.com/eve-autonomy/proj_launch/issues/7)

## Review Procedure

 * [x] Make sure the description is valid.
 * [x] Make sure that what is described in the description matches the implementation.