### PR TITLE
feat: add moudule graph

### DIFF
--- a/docs/module_graph.pu
+++ b/docs/module_graph.pu
@@ -1,0 +1,96 @@
+@startuml
+rectangle "autoware" {
+  usecase "autonomus module"
+}
+
+rectangle "v2i control function" {
+  usecase "v2i control module" #LightCoral
+}
+rectangle "user-defined/in-vehicle infrastructure device" {
+    node "broadcasting device"
+}
+rectangle "user-defined/infrastructure" {
+    node "v2i controller infrastructure"
+}
+
+rectangle "in-parking function" {
+    usecase "in_parking_module" #LightCoral
+}
+
+rectangle "engage function"{
+    usecase "engage module"  #LightCoral
+}
+
+rectangle "cargo loading management function"{
+  usecase "cargo_loading_service"  #LightCoral
+}
+
+rectangle "ondemand delivery reservation function" {
+  rectangle "web.auto" {
+    cloud "FMS (Fleet management system)" as FMS
+    usecase "Agent (Interface for FMS)" as Agent
+  }
+  rectangle "user-defined/saas" {
+    cloud "on-demand delivery apps" as DeliveryApp
+  }
+  usecase "/go_interface" #LightCoral
+}
+
+rectangle "Shutdown process management function" {
+    usecase "shutdown_manager" #LightCoral
+}
+
+rectangle "hmi control function" {
+  usecase "hmi control module" #LightCoral
+}
+
+  rectangle "user-defined/in-vehicle HMI devices" {
+    node "HMI devices"
+  }
+
+(v2i controller infrastructure) -right-> (broadcasting device) : wireless communication
+(v2i controller infrastructure) <-right- (broadcasting device) : " "
+
+
+
+(broadcasting device) <-- (v2i control module) : v2i command\n(UDP)
+(broadcasting device) --> (v2i control module) : v2i status\n(UDP)
+
+(v2i control module) --> (cargo_loading_service) : /v2i/infrastructer_states
+(v2i control module) <-- (cargo_loading_service) : /cargo_loding/infrastructure_commands
+(v2i control module) <-- (engage module) : /autoware_state_machine/state
+
+(engage module) -> (/go_interface) : req_change_lock_flg
+(engage module) <-- (/go_interface) : api_vehicle_status
+
+(cargo_loading_service) <-- (in_parking_module) : /in_parking/state\nSrvice:/in_parking/task
+(cargo_loading_service) .-> (in_parking_module) : " "
+
+
+(in_parking_module) --> (engage module) : /in_parkinge/set/auto_engage
+
+(v2i control module) <-- (autonomus module)  : /awapi/tmp/infrastructure_commands
+(v2i control module) --> (autonomus module)  : /system/v2x/virtual_traffic_light_states
+
+
+(autonomus module) <--- (engage module) : Service:\n/api/autoware/set/engage\n/api/autoware/set/start_request
+(autonomus module) .--> (engage module) 
+
+(autonomus module) --> (hmi control module) : /awapi/vehicle/get/status
+
+(FMS) -> (DeliveryApp)
+(FMS) <- (DeliveryApp)
+(FMS) --> (Agent)
+(FMS) <-- (Agent)
+(Agent) -> (/go_interface) : /webauto/vehicle_info
+(DeliveryApp) -->  (/go_interface) : result of GET API
+(DeliveryApp) <-- (/go_interface) : request of GET API\nrequest of PATCH API
+
+(hmi control module) <-- (engage module) : /autoware_state_machine/state
+
+(hmi control module) --> (HMI devices)
+(hmi control module)--> (shutdown_manager)
+
+(autonomus module) --> (engage module) : /awapi/autoware/get/status\n/awapi/vehicle/get/status
+
+@enduml

--- a/docs/module_graph.pu
+++ b/docs/module_graph.pu
@@ -25,6 +25,10 @@ rectangle "cargo loading management function"{
   usecase "cargo_loading_service"  #LightCoral
 }
 
+rectangle "Recovery Emergency function"{
+  usecase "recovery emergency module"
+}
+
 rectangle "ondemand delivery reservation function" {
   rectangle "web.auto" {
     cloud "FMS (Fleet management system)" as FMS
@@ -71,7 +75,8 @@ rectangle "hmi control function" {
 
 (v2i control module) <-- (autonomus module)  : /awapi/tmp/infrastructure_commands
 (v2i control module) --> (autonomus module)  : /system/v2x/virtual_traffic_light_states
-
+(recovery emergency module) --> (autonomus module)
+(recovery emergency module) <-- (autonomus module)
 
 (autonomus module) <--- (engage module) : Service:\n/api/autoware/set/engage\n/api/autoware/set/start_request
 (autonomus module) .--> (engage module) 


### PR DESCRIPTION
# Description
Create a component diagram because it would be complicated to put together the node diagrams related to proj launch.
The role of a component diagram is to summarize the functional configuration.

# Test Performed
It has been confirmed that the functions included in the package launched with proj launch are listed in the component diagram.

| No. | proj.launch.xml | component graph |
|---|---|---|
|1|audio_driver|hmi control module|
|2|dio_ros_driver|hmi control module|
|3|button_manager|hmi control module|
|4|v2i_interface|v2i control module|
|5|warning_lamp_manager|hmi control module|
|6|ad_status_lamp_manager|hmi control module|
|7|delivery_reservation_lamp_manager|hmi control module|
|8|go_interface|go_interface|
|9|engage_srv_converter|hmi control module|
|10|button_output_selector|hmi control module|
|11|shutdown_manager|shutdown_manager|
|12|lanelet2_map_parse_service|in_parking_module|
|13|engage_relay_service|engage module|
|14|cargo_loading_service|cargo_loading_service|
|15|in_parking_state_manager|in_parking_module|
|16|in_parking_task_manager|in_parking_module|
|17|v2i_command_muxer|v2i control module|
|18|vtl_adapter|v2i control module|
|19|emergency_holding_cancellation|recovery emergency module|

