### PR TITLE
feat: proj-launch-adapi-stateless-migration

### DIFF
--- a/launch/proj.launch.xml
+++ b/launch/proj.launch.xml
@@ -102,6 +102,11 @@
     <include file="$(find-pkg-share engage_srv_converter)/launch/engage_srv_converter.launch.xml" />
   </group>
   <group>
+    <include file="$(find-pkg-share autoware_state_machine)/launch/autoware_state_machine.launch.xml">
+      <arg name="use_overridable_vehicle" value="$(var use_overridable_vehicle)" />
+    </include>
+  </group>
+  <group>
     <include file="$(find-pkg-share eve_cmd_gate)/launch/eve_cmd_gate.launch.xml" />
   </group>
   <group>


### PR DESCRIPTION
## Related Links
https://tier4.atlassian.net/browse/AEAP-3956

## Description

本PRは、awapiからadapi移行によるproj_launchの実装をリリース用ブランチにマージする対応である。

[adapi移行対応](https://github.com/eve-autonomy/proj_launch/tree/feat/adapi-stateless-migration)から[リリース用ブランチ](https://github.com/eve-autonomy/proj_launch/tree/beta/v2.0.0)へのマージ

### 詳細
proj_launchリポジトリは書き込み権限がないためforkを作成してマージを実施

## Test
- マージ先がeve-autonomy配下のbeta/v2.0.0へのマージであることを確認
<img width="970" height="114" alt="image" src="https://github.com/user-attachments/assets/1bbab839-b1f7-49d8-80bd-ba28db9cb2f1" />

